### PR TITLE
Fix GPU tensor handling in to_pil_image

### DIFF
--- a/k_diffusion/utils.py
+++ b/k_diffusion/utils.py
@@ -31,6 +31,7 @@ def to_pil_image(x):
         x = x[0]
     if x.shape[0] == 1:
         x = x[0]
+    x = x.cpu()
     return TF.to_pil_image((x.clamp(-1, 1) + 1) / 2)
 
 


### PR DESCRIPTION
## Summary
- ensure tensors are moved to CPU in `to_pil_image`

## Testing
- `python -m py_compile k_diffusion/utils.py`