### PR TITLE
Add well log dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ PNG images arranged under `vel_dataset_processed` and uses the configuration
 ```sh
 $ ./train_fixed.py --config configs/config_vel.json --name RUN_NAME
 ```
+
+### Well log example
+
+A minimal loader for 1‑D well log data is provided in
+`datasets/well_log_dataset.py`. It expects `.npy` files inside the directory
+specified by `configs/config_well_log.json`.
+
+```sh
+$ accelerate launch train.py --config configs/config_well_log.json --name RUN_NAME
+```
 ## Enhancements/additional features
 
 - k-diffusion supports a highly efficient hierarchical transformer model type.

--- a/configs/config_well_log.json
+++ b/configs/config_well_log.json
@@ -1,0 +1,48 @@
+{
+    "model": {
+        "type": "image_v1",
+        "input_channels": 1,
+        "input_size": [256, 1],
+        "patch_size": 1,
+        "mapping_out": 256,
+        "depths": [2, 4, 4],
+        "channels": [64, 128, 256],
+        "self_attn_depths": [false, false, false],
+        "has_variance": false,
+        "loss_config": "karras",
+        "loss_weighting": "soft-min-snr",
+        "dropout_rate": 0.05,
+        "augment_wrapper": true,
+        "augment_prob": 0.0,
+        "sigma_data": 0.6162,
+        "sigma_min": 0.01,
+        "sigma_max": 80,
+        "sigma_sample_density": {
+            "type": "cosine-interpolated"
+        }
+    },
+    "dataset": {
+        "type": "custom",
+        "location": "../datasets/well_log_dataset.py",
+        "config": {
+            "root": "well_logs",
+            "length": 256
+        }
+    },
+    "optimizer": {
+        "type": "adamw",
+        "lr": 0.0002,
+        "betas": [0.95, 0.999],
+        "eps": 0.000001,
+        "weight_decay": 0.001
+    },
+    "lr_sched": {
+        "type": "constant",
+        "warmup": 0.0
+    },
+    "ema_sched": {
+        "type": "inverse",
+        "power": 0.6667,
+        "max_value": 0.9999
+    }
+}

--- a/datasets/well_log_dataset.py
+++ b/datasets/well_log_dataset.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from torch.utils import data
+import torch.nn.functional as F
+
+
+class WellLogDataset(data.Dataset):
+    """Loads 1-D well log samples stored as ``.npy`` files."""
+
+    def __init__(self, root: str, length: int) -> None:
+        self.root = Path(root)
+        self.paths = sorted(self.root.glob('*.npy'))
+        if not self.paths:
+            raise RuntimeError(f'no .npy files found in {self.root}')
+        self.length = length
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.paths)
+
+    def __getitem__(self, index: int):  # type: ignore[override]
+        arr = np.load(self.paths[index]).astype(np.float32)
+        if arr.ndim == 1:
+            arr = arr[None, :]
+        tensor = torch.from_numpy(arr)
+        if tensor.shape[-1] > self.length:
+            start = torch.randint(0, tensor.shape[-1] - self.length + 1, ()).item()
+            tensor = tensor[..., start:start + self.length]
+        elif tensor.shape[-1] < self.length:
+            pad = self.length - tensor.shape[-1]
+            tensor = F.pad(tensor, (0, pad))
+        tensor = tensor.unsqueeze(-1)
+        aug_cond = torch.zeros(9, dtype=torch.float32)
+        return tensor, tensor.clone(), aug_cond
+
+
+def get_dataset(config: dict, transform: Optional[callable] = None) -> WellLogDataset:
+    """Factory used by ``train.py`` to construct the dataset."""
+    root = config['root']
+    length = config.get('length', 256)
+    return WellLogDataset(root, length)


### PR DESCRIPTION
## Summary
- add a dataset helper for 1-D well log arrays
- add configuration using the new dataset
- document how to train on well logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871ef7a76ec832796dc7d9431a98a0c